### PR TITLE
Resolve missing build files

### DIFF
--- a/BUILD_FIX_SUMMARY.md
+++ b/BUILD_FIX_SUMMARY.md
@@ -1,0 +1,54 @@
+# TeleprompterApp Build Issues - Fixed
+
+## Issues Resolved
+
+### 1. Missing Entitlements File
+**Problem**: Build input file cannot be found: `TeleprompterApp.entitlements`
+**Solution**: 
+- Created `TeleprompterApp.entitlements` in the root directory
+- Added basic macOS app sandbox entitlements including:
+  - App sandbox capability
+  - User-selected file read/write access
+  - Network client access  
+  - Downloads folder read/write access
+- Updated project configuration to reference the correct path
+
+### 2. Missing Preview Content Directory
+**Problem**: Path in DEVELOPMENT_ASSET_PATHS does not exist: `Preview Content`
+**Solution**:
+- Created `Preview Content` directory in the root
+- Added `Preview Assets.xcassets` with proper Contents.json
+- Updated project configuration to reference the correct path
+
+### 3. Incorrect Project Path Configuration
+**Problem**: Xcode project was configured to look for files in `TeleprompterApp/` subdirectory, but files were in root
+**Solution**:
+- Updated `CODE_SIGN_ENTITLEMENTS` path from `TeleprompterApp/TeleprompterApp.entitlements` to `TeleprompterApp.entitlements`
+- Updated `DEVELOPMENT_ASSET_PATHS` from `"TeleprompterApp/Preview Content"` to `"Preview Content"`
+- Removed incorrect `path = TeleprompterApp;` from the project group structure
+- Added proper file reference for the entitlements file in the Xcode project
+
+## Files Created/Modified
+
+### Created Files:
+- `TeleprompterApp.entitlements` - App sandbox entitlements
+- `Preview Content/` directory
+- `Preview Content/Preview Assets.xcassets/Contents.json` - Preview assets configuration
+
+### Modified Files:
+- `TeleprompterApp.xcodeproj/project.pbxproj` - Fixed file paths and references
+
+## Current Project Structure
+```
+/workspace/
+├── TeleprompterApp.entitlements
+├── Preview Content/
+│   └── Preview Assets.xcassets/
+│       └── Contents.json
+├── TeleprompterApp.xcodeproj/
+│   └── project.pbxproj
+├── *.swift files (all in root)
+└── Info.plist
+```
+
+The project should now build successfully without the previous path-related errors.

--- a/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TeleprompterApp.entitlements
+++ b/TeleprompterApp.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+</dict>
+</plist>

--- a/TeleprompterApp.xcodeproj/project.pbxproj
+++ b/TeleprompterApp.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		024 /* iPadTextInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iPadTextInputView.swift; sourceTree = "<group>"; };
 		025 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		026 /* TeleprompterApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TeleprompterApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		041 /* TeleprompterApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TeleprompterApp.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,8 +74,8 @@
 				022 /* iPadTextDisplayView.swift */,
 				024 /* iPadTextInputView.swift */,
 				025 /* Info.plist */,
+				041 /* TeleprompterApp.entitlements */,
 			);
-			path = TeleprompterApp;
 			sourceTree = "<group>";
 		};
 		030 /* Products */ = {
@@ -290,10 +291,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = TeleprompterApp/TeleprompterApp.entitlements;
+				CODE_SIGN_ENTITLEMENTS = TeleprompterApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"TeleprompterApp/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "\"Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -333,10 +334,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = TeleprompterApp/TeleprompterApp.entitlements;
+				CODE_SIGN_ENTITLEMENTS = TeleprompterApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"TeleprompterApp/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "\"Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;


### PR DESCRIPTION
Fix Xcode build errors by aligning project file paths with the actual file structure and creating missing entitlements and preview content.

The project was configured to look for `TeleprompterApp.entitlements` and `Preview Content` within a `TeleprompterApp/` subdirectory, but these files were located directly in the project root. This PR corrects these path references and creates the necessary files.